### PR TITLE
Add support for Python < 3.8

### DIFF
--- a/src/faithfulness/NER.py
+++ b/src/faithfulness/NER.py
@@ -1,10 +1,15 @@
-from typing import List, TypedDict, Dict, Type
+import sys
 import spacy
 import numpy as np
 from faithfulness.interfaces.FaithfulnessInput import FaithfulnessInput
 from faithfulness.interfaces.MetricInterface import MetricInterface
 from faithfulness.interfaces.SimilarityMetricInterface import SimilarityMetricInterface
 from tqdm import tqdm
+from typing import List, Dict, Type
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 from faithfulness.interfaces.UsesSimilarityMetricInterface import UsesSimilarityMetricInterface
 from faithfulness.types.GroupedAlignScoreResult import GroupedAlignScoreResult

--- a/src/faithfulness/OpenIE.py
+++ b/src/faithfulness/OpenIE.py
@@ -1,5 +1,5 @@
+import sys
 import pathlib
-from typing import List, Type, Dict, TypedDict, Tuple, Optional
 import torch
 from sentence_transformers import SentenceTransformer, util
 from sklearn.cluster import DBSCAN
@@ -14,6 +14,11 @@ from faithfulness.types.AlignScoreResult import AlignScoreResult
 from faithfulness.utils.representation_utils import Phrase
 from faithfulness.utils.utils import load_data, save_data, ensure_dir_exists
 from tqdm import tqdm
+from typing import List, Type, Dict, Tuple
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class Triple(TypedDict):

--- a/src/faithfulness/QGQA.py
+++ b/src/faithfulness/QGQA.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Type, Dict, TypedDict, Tuple, Optional
+import sys
 import spacy
 import torch
 from torch.utils.data import DataLoader
@@ -12,6 +12,11 @@ from faithfulness.interfaces.SimilarityMetricInterface import SimilarityMetricIn
 from faithfulness.utils.Datasets import QGDataset
 from tqdm import tqdm
 from faithfulness.utils.utils import load_data, save_data, ensure_dir_exists, is_PRF1Result, is_F1Result
+from typing import List, Type, Dict, Tuple, Optional
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class AnswerCandidate(TypedDict):

--- a/src/faithfulness/utils/utils.py
+++ b/src/faithfulness/utils/utils.py
@@ -1,12 +1,16 @@
+import sys
 import json
 import pathlib
 import pickle
 import re
 import string
 from enum import Enum
-from typing import TypedDict
 import pandas as pd
 from pandas import DataFrame
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class F1Result(TypedDict):


### PR DESCRIPTION
This PR adds support for Python < 3.8.

The motivation behind this PR is that I wanted to check the module on Google Colab, but since it (surprisingly) still runs Python 3.7, the `typing.TypedDict` import was failing. This type was introduced in Python 3.8.

Fortunately or unfortunately, the reality is that a lot of people use Colab, so making the module work on it will probably be helpful for the project.

The fix is based on https://github.com/python/typeshed/issues/3500#issuecomment-560958608.